### PR TITLE
Metrics Optimization

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -4,7 +4,7 @@ Optimization exercise on an example metrics program which calculates averages an
 
 * `metrics_baseline.go` is the program as given.
 
-* `metrics_optized.go` is an optimized version that uses an array-based vs object-oriented approach.
+* `metrics_array.go` is an optimized version that uses an array-based vs object-oriented approach.
 
 * `metrics_streaming.go` is a second optimized version that uses a single pass through the source files.
 
@@ -15,9 +15,9 @@ To run benchmarks:
 goos: darwin
 goarch: amd64
 cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
-BenchmarkMetrics/Metrics_Baseline-12                   1        1425283274 ns/op        544903984 B/op   5867781 allocs/op
-BenchmarkMetrics/Metrics_Optimized-12                  4         311954067 ns/op        271589242 B/op   2200097 allocs/op
-BenchmarkMetrics/Metrics_Streaming-12                  6         174200070 ns/op        112461762 B/op   2200009 allocs/op
+BenchmarkMetrics/Metrics_Baseline-12                   1        1450591279 ns/op  544892904 B/op   5867714 allocs/op
+BenchmarkMetrics/Metrics_Array-12                      4         313136749 ns/op  271589240 B/op   2200097 allocs/op
+BenchmarkMetrics/Metrics_Streaming-12                  6         172643944 ns/op  112461893 B/op   2200010 allocs/op
 PASS
-ok      command-line-arguments  5.405s
+ok      command-line-arguments  6.349s
 ```

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,0 +1,23 @@
+# Metrics Optimization
+
+Optimization exercise on an example metrics program which calculates averages and standard deviation across a mock dataset of users and their payments.
+
+* `metrics_baseline.go` is the program as given.
+
+* `metrics_optized.go` is an optimized version that uses an array-based vs object-oriented approach.
+
+* `metrics_streaming.go` is a second optimized version that uses a single pass through the source files.
+
+To run benchmarks:
+
+```sh
+➜  go test -bench=. -benchmem metrics_baseline.go metrics_test.go metrics_optimized.go metrics_streaming.go metrics_shared.go
+goos: darwin
+goarch: amd64
+cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+BenchmarkMetrics/Metrics_Baseline-12                   1        1425283274 ns/op        544903984 B/op   5867781 allocs/op
+BenchmarkMetrics/Metrics_Optimized-12                  4         311954067 ns/op        271589242 B/op   2200097 allocs/op
+BenchmarkMetrics/Metrics_Streaming-12                  6         174200070 ns/op        112461762 B/op   2200009 allocs/op
+PASS
+ok      command-line-arguments  5.405s
+```

--- a/metrics/metrics_array.go
+++ b/metrics/metrics_array.go
@@ -13,7 +13,7 @@ type UserArrays struct {
 	payments []uint64
 }
 
-func AverageAgeOptimized(users UserArrays) float64 {
+func AverageAgeArray(users UserArrays) float64 {
 	sum := uint64(0)
 	for _, age := range users.ages {
 		sum += uint64(age)
@@ -21,7 +21,7 @@ func AverageAgeOptimized(users UserArrays) float64 {
 	return float64(sum) / float64(len(users.ages))
 }
 
-func AveragePaymentAmountOptimized(users UserArrays) float64 {
+func AveragePaymentAmountArray(users UserArrays) float64 {
 	sum := uint64(0)
 	for _, payment := range users.payments {
 		sum += payment;
@@ -30,7 +30,7 @@ func AveragePaymentAmountOptimized(users UserArrays) float64 {
 }
 
 // Sum of squares method, taken from https://play.golang.org/p/xQXiHFzmxxN
-func StdDevPaymentAmountOptimized(users UserArrays) float64 {
+func StdDevPaymentAmountArray(users UserArrays) float64 {
 	sumSquares, sum := float64(0), float64(0)
 	numPayments := float64(len(users.payments))
 
@@ -44,7 +44,7 @@ func StdDevPaymentAmountOptimized(users UserArrays) float64 {
 	return math.Sqrt(avgSquares - avg*avg)
 }
 
-func LoadDataOptimized() UserArrays {
+func LoadDataArray() UserArrays {
 	f, err := os.Open("users.csv")
 	if err != nil {
 		log.Fatalln("Unable to read users.csv", err)
@@ -80,8 +80,8 @@ func LoadDataOptimized() UserArrays {
 	return UserArrays{ages, payments}
 }
 
-func CalculateMetricsOptimized() Metrics {
-	userArrays := LoadDataOptimized()
+func CalculateMetricsArray() Metrics {
+	userArrays := LoadDataArray()
 
-	return Metrics{AverageAgeOptimized(userArrays), AveragePaymentAmountOptimized(userArrays), StdDevPaymentAmountOptimized(userArrays) }
+	return Metrics{AverageAgeArray(userArrays), AveragePaymentAmountArray(userArrays), StdDevPaymentAmountArray(userArrays) }
 }

--- a/metrics/metrics_baseline.go
+++ b/metrics/metrics_baseline.go
@@ -1,0 +1,121 @@
+package metrics
+
+import (
+	"encoding/csv"
+	"log"
+	"math"
+	"os"
+	"strconv"
+	"time"
+)
+
+type UserId int
+type UserMap map[UserId]*User
+
+type Address struct {
+	fullAddress string
+	zip         int
+}
+
+type DollarAmount struct {
+	dollars, cents uint64
+}
+
+type Payment struct {
+	amount DollarAmount
+	time   time.Time
+}
+
+type User struct {
+	id       UserId
+	name     string
+	age      int
+	address  Address
+	payments []Payment
+}
+
+func AverageAge(users UserMap) float64 {
+	average, count := 0.0, 0.0
+	for _, u := range users {
+		count += 1
+		average += (float64(u.age) - average) / count
+	}
+	return average
+}
+
+func AveragePaymentAmount(users UserMap) float64 {
+	average, count := 0.0, 0.0
+	for _, u := range users {
+		for _, p := range u.payments {
+			count += 1
+			amount := float64(p.amount.dollars) + float64(p.amount.cents)/100
+			average += (amount - average) / count
+		}
+	}
+	return average
+}
+
+// Compute the standard deviation of payment amounts
+func StdDevPaymentAmount(users UserMap) float64 {
+	mean := AveragePaymentAmount(users)
+	squaredDiffs, count := 0.0, 0.0
+	for _, u := range users {
+		for _, p := range u.payments {
+			count += 1
+			amount := float64(p.amount.dollars) + float64(p.amount.cents)/100
+			diff := amount - mean
+			squaredDiffs += diff * diff
+		}
+	}
+	return math.Sqrt(squaredDiffs / count)
+}
+
+func LoadData() UserMap {
+	f, err := os.Open("users.csv")
+	if err != nil {
+		log.Fatalln("Unable to read users.csv", err)
+	}
+	reader := csv.NewReader(f)
+	userLines, err := reader.ReadAll()
+	if err != nil {
+		log.Fatalln("Unable to parse users.csv as csv", err)
+	}
+
+	users := make(UserMap, len(userLines))
+	for _, line := range userLines {
+		id, _ := strconv.Atoi(line[0])
+		name := line[1]
+		age, _ := strconv.Atoi(line[2])
+		address := line[3]
+		zip, _ := strconv.Atoi(line[3])
+		users[UserId(id)] = &User{UserId(id), name, age, Address{address, zip}, []Payment{}}
+	}
+
+	f, err = os.Open("payments.csv")
+	if err != nil {
+		log.Fatalln("Unable to read payments.csv", err)
+	}
+	reader = csv.NewReader(f)
+	paymentLines, err := reader.ReadAll()
+	if err != nil {
+		log.Fatalln("Unable to parse payments.csv as csv", err)
+	}
+
+	for _, line := range paymentLines {
+		userId, _ := strconv.Atoi(line[2])
+		paymentCents, _ := strconv.Atoi(line[0])
+		datetime, _ := time.Parse(time.RFC3339, line[1])
+		users[UserId(userId)].payments = append(users[UserId(userId)].payments, Payment{
+			DollarAmount{uint64(paymentCents / 100), uint64(paymentCents % 100)},
+			datetime,
+		})
+	}
+
+	return users
+}
+
+func CalculateMetrics() Metrics {
+	userMap := LoadData()
+
+	return Metrics{AverageAge(userMap), AveragePaymentAmount(userMap), StdDevPaymentAmount(userMap) }
+}

--- a/metrics/metrics_optimized.go
+++ b/metrics/metrics_optimized.go
@@ -1,0 +1,87 @@
+package metrics
+
+import (
+	"encoding/csv"
+	"log"
+	"os"
+	"strconv"
+	"math"
+)
+
+type UserArrays struct {
+	ages []uint8
+	payments []uint64
+}
+
+func AverageAgeOptimized(users UserArrays) float64 {
+	sum := uint64(0)
+	for _, age := range users.ages {
+		sum += uint64(age)
+	}
+	return float64(sum) / float64(len(users.ages))
+}
+
+func AveragePaymentAmountOptimized(users UserArrays) float64 {
+	sum := uint64(0)
+	for _, payment := range users.payments {
+		sum += payment;
+	}
+	return float64(sum) / 100.0 / float64(len(users.payments))
+}
+
+// Sum of squares method, taken from https://play.golang.org/p/xQXiHFzmxxN
+func StdDevPaymentAmountOptimized(users UserArrays) float64 {
+	sumSquares, sum := float64(0), float64(0)
+	numPayments := float64(len(users.payments))
+
+	for _, payment := range users.payments {
+		x := float64(payment) / 100.0
+		sumSquares += x * x
+		sum += x
+	}
+	avgSquares := sumSquares / numPayments
+	avg := sum / numPayments
+	return math.Sqrt(avgSquares - avg*avg)
+}
+
+func LoadDataOptimized() UserArrays {
+	f, err := os.Open("users.csv")
+	if err != nil {
+		log.Fatalln("Unable to read users.csv", err)
+	}
+	reader := csv.NewReader(f)
+	userLines, err := reader.ReadAll()
+	if err != nil {
+		log.Fatalln("Unable to parse users.csv as csv", err)
+	}
+
+	ages := make([]uint8, len(userLines))
+	for i, line := range userLines {
+		age, _ := strconv.Atoi(line[2])
+		ages[i] = uint8(age)
+	}
+
+	f, err = os.Open("payments.csv")
+	if err != nil {
+		log.Fatalln("Unable to read payments.csv", err)
+	}
+	reader = csv.NewReader(f)
+	paymentLines, err := reader.ReadAll()
+	if err != nil {
+		log.Fatalln("Unable to parse payments.csv as csv", err)
+	}
+
+	payments := make([]uint64, len(paymentLines))
+	for i, line := range paymentLines {
+		payment, _ := strconv.ParseUint(line[0], 10, 64)
+		payments[i] = uint64(payment)
+	}
+
+	return UserArrays{ages, payments}
+}
+
+func CalculateMetricsOptimized() Metrics {
+	userArrays := LoadDataOptimized()
+
+	return Metrics{AverageAgeOptimized(userArrays), AveragePaymentAmountOptimized(userArrays), StdDevPaymentAmountOptimized(userArrays) }
+}

--- a/metrics/metrics_shared.go
+++ b/metrics/metrics_shared.go
@@ -1,0 +1,7 @@
+package metrics
+
+type Metrics struct {
+	averageAge	float64
+	averagePaymentAmount float64
+	stdDevPaymentAmount float64
+}

--- a/metrics/metrics_streaming.go
+++ b/metrics/metrics_streaming.go
@@ -1,0 +1,56 @@
+package metrics
+
+import (
+	"os"
+	"log"
+	"strconv"
+	"math"
+	"strings"
+	"bufio"
+)
+
+func CalculateMetricStreaming() Metrics {
+	averageAge := 0.0
+	averagePaymentAmount := 0.0
+	stdDevPaymentAmount := 0.0
+
+	f, err := os.Open("payments.csv")
+	if err != nil {
+		log.Fatalln("Unable to read payments.csv", err)
+	}
+
+	numPayments, delta, M2 := 0.0, 0.0, 0.0
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		paymentCents, _ := strconv.Atoi(strings.Split(scanner.Text(), ",")[0])
+		payment := float64(paymentCents) / 100.0
+
+		numPayments++
+		
+		// Calculate StdDev using Welford's Online Algorithm
+		// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
+		delta = payment - averagePaymentAmount
+		averagePaymentAmount += delta / numPayments
+		M2 += delta * (payment - averagePaymentAmount)
+	}
+
+	averagePaymentAmount = averagePaymentAmount
+	stdDevPaymentAmount = math.Sqrt(M2 / numPayments)
+
+	sumAges, numUsers := 0, 0
+	f, err = os.Open("users.csv")
+	if err != nil {
+		log.Fatalln("Unable to read users.csv", err)
+	}
+	scanner = bufio.NewScanner(f)
+	for scanner.Scan() {
+		age, _ := strconv.Atoi(strings.Split(scanner.Text(), ",")[2])
+		numUsers++
+		sumAges += age
+	}
+
+	averageAge = float64(sumAges) / float64(numUsers);
+
+	return Metrics{averageAge, averagePaymentAmount, stdDevPaymentAmount}
+}
+

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -29,11 +29,11 @@ func BenchmarkMetrics(b *testing.B) {
 		}
 	})
 
-	b.Run("Metrics Optimized", func(b *testing.B) {
+	b.Run("Metrics Array", func(b *testing.B) {
 		var metrics Metrics
 
 		for n := 0; n < b.N; n++ {
-			metrics = CalculateMetricsOptimized()
+			metrics = CalculateMetricsArray()
 		}
 
 		expectedAverageAge := 59.62

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,0 +1,78 @@
+package metrics
+
+import (
+	"math"
+	"testing"
+)
+
+func BenchmarkMetrics(b *testing.B) {
+	b.Run("Metrics Baseline", func(b *testing.B) {
+		var metrics Metrics
+
+		for n := 0; n < b.N; n++ {
+			metrics = CalculateMetrics()
+		}
+
+		expectedAverageAge := 59.62
+		if math.IsNaN(metrics.averageAge) || math.Abs(metrics.averageAge - expectedAverageAge) > 0.01 {
+			b.Fatalf("Expected average age to be around %.2f, not %.3f", expectedAverageAge, metrics.averageAge)
+		}
+
+		expectedAveragePaymentAmount := 499850.559
+		if math.IsNaN(metrics.averagePaymentAmount) || math.Abs(metrics.averagePaymentAmount-expectedAveragePaymentAmount) > 0.01 {
+			b.Fatalf("Expected average payment amount to be around %.2f, not %.3f", expectedAveragePaymentAmount, metrics.averagePaymentAmount)
+		}
+
+		expectedStdDevAmount := 288684.850
+		if math.IsNaN(metrics.stdDevPaymentAmount) || math.Abs(metrics.stdDevPaymentAmount-expectedStdDevAmount) > 0.01 {
+			b.Fatalf("Expected standard deviation to be around %.2f, not %.3f", expectedStdDevAmount, metrics.stdDevPaymentAmount)
+		}
+	})
+
+	b.Run("Metrics Optimized", func(b *testing.B) {
+		var metrics Metrics
+
+		for n := 0; n < b.N; n++ {
+			metrics = CalculateMetricsOptimized()
+		}
+
+		expectedAverageAge := 59.62
+		if math.IsNaN(metrics.averageAge) || math.Abs(metrics.averageAge - expectedAverageAge) > 0.01 {
+			b.Fatalf("Expected average age to be around %.2f, not %.3f", expectedAverageAge, metrics.averageAge)
+		}
+
+		expectedAveragePaymentAmount := 499850.559
+		if math.IsNaN(metrics.averagePaymentAmount) || math.Abs(metrics.averagePaymentAmount-expectedAveragePaymentAmount) > 0.01 {
+			b.Fatalf("Expected average payment amount to be around %.2f, not %.3f", expectedAveragePaymentAmount, metrics.averagePaymentAmount)
+		}
+
+		expectedStdDevAmount := 288684.850
+		if math.IsNaN(metrics.stdDevPaymentAmount) || math.Abs(metrics.stdDevPaymentAmount-expectedStdDevAmount) > 0.01 {
+			b.Fatalf("Expected standard deviation to be around %.2f, not %.3f", expectedStdDevAmount, metrics.stdDevPaymentAmount)
+		}
+	})
+
+
+	b.Run("Metrics Streaming", func(b *testing.B) {
+		var metrics Metrics
+
+		for n := 0; n < b.N; n++ {
+			metrics = CalculateMetricStreaming()
+		}
+
+		expectedAverageAge := 59.62
+		if math.IsNaN(metrics.averageAge) || math.Abs(metrics.averageAge - expectedAverageAge) > 0.01 {
+			b.Fatalf("Expected average age to be around %.2f, not %.3f", expectedAverageAge, metrics.averageAge)
+		}
+
+		expectedAveragePaymentAmount := 499850.559
+		if math.IsNaN(metrics.averagePaymentAmount) || math.Abs(metrics.averagePaymentAmount-expectedAveragePaymentAmount) > 0.01 {
+			b.Fatalf("Expected average payment amount to be around %.2f, not %.3f", expectedAveragePaymentAmount, metrics.averagePaymentAmount)
+		}
+
+		expectedStdDevAmount := 288684.850
+		if math.IsNaN(metrics.stdDevPaymentAmount) || math.Abs(metrics.stdDevPaymentAmount-expectedStdDevAmount) > 0.01 {
+			b.Fatalf("Expected standard deviation to be around %.2f, not %.3f", expectedStdDevAmount, metrics.stdDevPaymentAmount)
+		}
+	})
+}


### PR DESCRIPTION
Prework for Memory Hierarchy 2. I have two versions: `metrics_optimized` which uses an array-based approach, and `metrics_streaming` which calculates metrics via single passes through the source files. Here are the results:

```
goos: darwin
goarch: amd64
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkMetrics/Metrics_Baseline-12                   1        1450591279 ns/op  544892904 B/op   5867714 allocs/op
BenchmarkMetrics/Metrics_Array-12                      4         313136749 ns/op  271589240 B/op   2200097 allocs/op
BenchmarkMetrics/Metrics_Streaming-12                  6         172643944 ns/op  112461893 B/op   2200010 allocs/op
PASS
```